### PR TITLE
Fix hardware package export

### DIFF
--- a/hardware/__init__.py
+++ b/hardware/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "get_supported_gpus",
     "compare_gpus",
     "validate_gpu_configuration",
+    "get_module_info",
 ]
 
 


### PR DESCRIPTION
## Summary
- export `get_module_info` via `hardware.__all__`

## Testing
- `python tests/test_hardware_module.py -q`
- `python tests/test_configuration.py -q` *(fails: ModuleNotFoundError: numpy)*
- `python tests/test_power_modeling_framework.py -q` *(fails: ModuleNotFoundError: numpy)*
- `python tests/test_integration.py -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686b06b4880c8329a844500208218cc6