### PR TITLE
Derive GPU freq counts from config

### DIFF
--- a/tests/test_power_modeling_framework.py
+++ b/tests/test_power_modeling_framework.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import config
 
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -232,7 +233,11 @@ class TestPowerModelingFramework(unittest.TestCase):
 
     def test_gpu_frequency_configurations(self):
         """Test GPU frequency configurations are correct."""
-        expected_counts = {"V100": 131, "A100": 61, "H100": 104}
+        expected_counts = {
+            "V100": len(config.gpu_config.V100_CORE_FREQUENCIES),
+            "A100": len(config.gpu_config.A100_CORE_FREQUENCIES),
+            "H100": len(config.gpu_config.H100_CORE_FREQUENCIES),
+        }
         expected_ranges = {
             "V100": (405, 1380),
             "A100": (510, 1410),


### PR DESCRIPTION
## Summary
- compute GPU frequency counts in tests from `config.gpu_config`
- import `config` in the test file

## Testing
- `pytest tests/test_power_modeling_framework.py::TestPowerModelingFramework.test_gpu_frequency_configurations -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686b09e93ca8832995bfe036dc58bcdc