### PR TITLE
Revert docs to Python 3.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ As AI workloads grow in complexity and energy demand, static frequency settings 
 - ⚡ **Intelligent Fallback**: Automatic tool selection when DCGMI is unavailable
 - 📈 **Comprehensive Logging**: Enterprise-grade error handling and progress tracking
 - 🔄 **Professional Architecture**: Modular, maintainable, and extensible codebase
-- 🐍 **Python 3.6+ Compatible**: Works on older cluster environments
+ - 🐍 **Python 3.6+ Compatible**: Works on older cluster environments
 - 🧠 **Advanced Power Modeling**: ML-based power prediction with EDP optimization
 - ⚡ **EDP Analysis**: Energy-Delay Product and ED²P optimization for optimal frequency selection
 - 🔬 **Model Validation**: Comprehensive validation framework with robust error handling

--- a/app-lstm/README.md
+++ b/app-lstm/README.md
@@ -98,7 +98,7 @@ embedding_output_dims = 30
 - **GPU utilization**: Good balance of compute and memory operations
 - **Scalable**: Easily adjustable for different experiment needs
 
-## Requirements
+-## Requirements
 
 - Python 3.6+
 - TensorFlow 2.x

--- a/sample-collection-scripts/README.md
+++ b/sample-collection-scripts/README.md
@@ -225,13 +225,13 @@ results/
 ### For DCGMI
 - NVIDIA GPU (A100/V100)
 - DCGMI tools installed
-- Python 3.8+
+- Python 3.6+
 - Permissions for GPU control
 
 ### For nvidia-smi  
 - NVIDIA GPU (A100/V100)
 - NVIDIA drivers (nvidia-smi)
-- Python 3.8+
+- Python 3.6+
 - May require sudo for frequency control
 
 ## Troubleshooting

--- a/utils.py
+++ b/utils.py
@@ -91,15 +91,13 @@ def run_command(
         subprocess.TimeoutExpired: If command times out
     """
     try:
-        # Python 3.6 compatibility: use stdout/stderr instead of capture_output
-        # and universal_newlines instead of text
         if capture_output:
             result = subprocess.run(
                 command,
                 timeout=timeout,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                universal_newlines=True,  # Python 3.6 compatible (text=True in 3.7+)
+                universal_newlines=True,
                 check=check,
             )
         else:
@@ -107,7 +105,7 @@ def run_command(
                 command,
                 timeout=timeout,
                 universal_newlines=True,
-                check=check,  # Python 3.6 compatible (text=True in 3.7+)
+                check=check,
             )
         return result
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- revert project docs back to Python 3.6+ references
- rename compatibility test script to Python 3.6
- update configuration module header
- require Python 3.6+ in configuration tests
- adjust sample script docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686c97a7571c83298c804dfd1ff285ef