### PR TITLE
Limit CI Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, dev, develop]
 
+env:
+  PYTHON_VERSION: '3.8'
+
 
 jobs:
   lint:
@@ -35,14 +38,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8"]
     steps:
       - uses: actions/checkout@v4
       
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           
       - name: Install essential tools

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -26,7 +26,7 @@ on:
     - cron: '0 3 1 * *'
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.8"
 
 jobs:
   gpu-frequency-validation:


### PR DESCRIPTION
## Summary
- set PYTHON_VERSION=3.8 for CI
- drop matrix to a single Python version
- update GPU tests to use Python 3.8

## Testing
- `make test` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686d528ca010832986e08bdd8d16cd2d