### PR TITLE
Use sys.path.insert for integration test imports

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 
 # Add parent directory to path for imports
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class TestDataProcessingIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- ensure local modules override installed packages in `test_integration.py`

## Testing
- `pytest -k test_integration -v tests/test_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_686d60c02510832992a047d85a3148fa