### PR TITLE
Capture logs in logging integration test

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -241,9 +241,11 @@ class TestSystemIntegration(unittest.TestCase):
 
         # Test logging doesn't break
         try:
-            logger.info("Test log message")
-            logger.warning("Test warning message")
-            logger.error("Test error message")
+            with self.assertLogs("test_power_modeling", level="INFO") as cm:
+                logger.info("Test log message")
+                logger.warning("Test warning message")
+                logger.error("Test error message")
+            self.assertEqual(len(cm.output), 3)
         except Exception as e:
             self.fail(f"Logging failed: {e}")
 


### PR DESCRIPTION
## Summary
- prevent console output from logs by capturing them in `test_logging_integration`

## Testing
- `pytest tests/test_integration.py::TestSystemIntegration::test_logging_integration -q`

------
https://chatgpt.com/codex/tasks/task_e_686d60e17968832997a95d6a7d53f040