### PR TITLE
Fix pytest collection errors for stable diffusion scripts

### DIFF
--- a/app-stable-diffusion/tests/complete_test.py
+++ b/app-stable-diffusion/tests/complete_test.py
@@ -2,12 +2,7 @@
 """
 Complete Stable Diffusion Environment Test - Final Version
 """
-print("🎯 COMPLETE STABLE DIFFUSION ENVIRONMENT TEST")
-print("=" * 55)
-print("Testing the exact working configuration for Tesla V100")
-print()
-
-def test_import(description, import_statement):
+def run_import_test(description, import_statement):
     """Test an import and return success status"""
     try:
         exec(import_statement)
@@ -45,50 +40,63 @@ tests = [
 passed = 0
 total = len(tests)
 
-for description, import_stmt in tests:
-    if test_import(description, import_stmt):
-        passed += 1
+def main():
+    print("🎯 COMPLETE STABLE DIFFUSION ENVIRONMENT TEST")
+    print("=" * 55)
+    print("Testing the exact working configuration for Tesla V100")
+    print()
+
+    global passed
+    for description, import_stmt in tests:
+        if run_import_test(description, import_stmt):
+            passed += 1
 
 # Show versions
-print("\n📦 PACKAGE VERSIONS:")
-print("-" * 30)
-print(f"PyTorch: {get_version('torch')}")
-print(f"transformers: {get_version('transformers')}")
-print(f"diffusers: {get_version('diffusers')}")
-print(f"huggingface_hub: {get_version('huggingface_hub')}")
-print(f"safetensors: {get_version('safetensors')}")
+    print("\n📦 PACKAGE VERSIONS:")
+    print("-" * 30)
+    print(f"PyTorch: {get_version('torch')}")
+    print(f"transformers: {get_version('transformers')}")
+    print(f"diffusers: {get_version('diffusers')}")
+    print(f"huggingface_hub: {get_version('huggingface_hub')}")
+    print(f"safetensors: {get_version('safetensors')}")
 
 # GPU Info
-print("\n🖥️  GPU INFORMATION:")
-print("-" * 25)
-try:
-    import torch
-    if torch.cuda.is_available():
-        print(f"GPU: {torch.cuda.get_device_name()}")
-        print(f"CUDA Version: {torch.version.cuda}")
-        print(f"GPU Memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB")
-    else:
-        print("No GPU available")
-except:
-    print("Cannot check GPU info")
+    print("\n🖥️  GPU INFORMATION:")
+    print("-" * 25)
+    try:
+        import torch
+        if torch.cuda.is_available():
+            print(f"GPU: {torch.cuda.get_device_name()}")
+            print(f"CUDA Version: {torch.version.cuda}")
+            print(
+                f"GPU Memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB"
+            )
+        else:
+            print("No GPU available")
+    except Exception:
+        print("Cannot check GPU info")
 
 # Final score
-print("\n" + "=" * 55)
-print(f"📊 FINAL SCORE: {passed}/{total} components working")
-print(f"🎯 SUCCESS RATE: {passed/total*100:.1f}%")
+    print("\n" + "=" * 55)
+    print(f"📊 FINAL SCORE: {passed}/{total} components working")
+    print(f"🎯 SUCCESS RATE: {passed/total*100:.1f}%")
 
-if passed == total:
-    print("\n🎉 PERFECT SCORE! STABLE DIFFUSION FULLY FUNCTIONAL!")
-    print("🚀 Ready for AI inference energy research!")
-    print("🖼️  Image generation: READY")
-    print("⚡ Energy profiling: READY")
-elif passed >= total - 2:
-    print(f"\n✅ EXCELLENT! {passed}/{total} working - Environment ready!")
-    print("🚀 Stable Diffusion should work for most use cases")
-else:
-    print(f"\n⚠️  {total-passed} components need attention")
+    if passed == total:
+        print("\n🎉 PERFECT SCORE! STABLE DIFFUSION FULLY FUNCTIONAL!")
+        print("🚀 Ready for AI inference energy research!")
+        print("🖼️  Image generation: READY")
+        print("⚡ Energy profiling: READY")
+    elif passed >= total - 2:
+        print(f"\n✅ EXCELLENT! {passed}/{total} working - Environment ready!")
+        print("🚀 Stable Diffusion should work for most use cases")
+    else:
+        print(f"\n⚠️  {total-passed} components need attention")
 
-print("\n🏆 CONFIGURATION SUMMARY:")
-print("   Tesla V100 + CUDA 11.0 + PyTorch 1.12.1")
-print("   transformers==4.33.2 + diffusers==0.21.4 + huggingface_hub==0.16.4")
-print("   = WORKING STABLE DIFFUSION ENVIRONMENT!")
+    print("\n🏆 CONFIGURATION SUMMARY:")
+    print("   Tesla V100 + CUDA 11.0 + PyTorch 1.12.1")
+    print("   transformers==4.33.2 + diffusers==0.21.4 + huggingface_hub==0.16.4")
+    print("   = WORKING STABLE DIFFUSION ENVIRONMENT!")
+
+
+if __name__ == "__main__":
+    main()

--- a/app-stable-diffusion/tests/final_success_test.py
+++ b/app-stable-diffusion/tests/final_success_test.py
@@ -2,10 +2,7 @@
 """
 Final success verification for Stable Diffusion environment
 """
-print("🎉 FINAL STABLE DIFFUSION SUCCESS TEST")
-print("=" * 50)
-
-def test_import(module_name, display_name=None, from_import=None):
+def run_import_test(module_name, display_name=None, from_import=None):
     if display_name is None:
         display_name = module_name
     try:
@@ -39,43 +36,51 @@ components = [
 working = 0
 total = len(components)
 
-for comp in components:
-    if len(comp) == 3:
-        module_name, display_name, from_import = comp
-        if test_import(module_name, display_name, from_import):
-            working += 1
-    else:
-        module_name, display_name = comp
-        if test_import(module_name, display_name):
-            working += 1
+def main():
+    print("🎉 FINAL STABLE DIFFUSION SUCCESS TEST")
+    print("=" * 50)
+
+    global working, total
+    for comp in components:
+        if len(comp) == 3:
+            module_name, display_name, from_import = comp
+            if run_import_test(module_name, display_name, from_import):
+                working += 1
+        else:
+            module_name, display_name = comp
+            if run_import_test(module_name, display_name):
+                working += 1
 
 # Test CUDA
-try:
-    import torch
-    cuda_available = torch.cuda.is_available()
-    if cuda_available:
-        device_name = torch.cuda.get_device_name()
-        print(f"✅ CUDA: Available ({device_name})")
-        working += 1
+    try:
+        import torch
+        cuda_available = torch.cuda.is_available()
+        if cuda_available:
+            device_name = torch.cuda.get_device_name()
+            print(f"✅ CUDA: Available ({device_name})")
+            working += 1
+        else:
+            print("❌ CUDA: Not available")
+        total += 1
+    except Exception:
+        print("❌ CUDA: Cannot test")
+        total += 1
+
+    print("\n" + "=" * 50)
+    print(f"📊 FINAL SCORE: {working}/{total} components working")
+    print(f"🎯 SUCCESS RATE: {working/total*100:.1f}%")
+
+    if working >= total - 1:  # Allow for 1 minor failure
+        print("\n🎉 STABLE DIFFUSION ENVIRONMENT: FULLY FUNCTIONAL!")
+        print("🚀 Ready for AI inference energy research!")
+        print("🖼️  Stable Diffusion image generation: READY")
+        print("⚡ Energy profiling capabilities: READY")
+        print("🔬 Tesla V100 GPU utilization: READY")
     else:
-        print("❌ CUDA: Not available")
-    total += 1
-except:
-    print("❌ CUDA: Cannot test")
-    total += 1
+        print(f"\n⚠️  {total-working} components need attention")
 
-print("\n" + "=" * 50)
-print(f"📊 FINAL SCORE: {working}/{total} components working")
-print(f"🎯 SUCCESS RATE: {working/total*100:.1f}%")
+    print("\n🏆 MISSION ACCOMPLISHED!")
 
-if working >= total - 1:  # Allow for 1 minor failure
-    print("\n🎉 STABLE DIFFUSION ENVIRONMENT: FULLY FUNCTIONAL!")
-    print("🚀 Ready for AI inference energy research!")
-    print("🖼️  Stable Diffusion image generation: READY")
-    print("⚡ Energy profiling capabilities: READY")
-    print("🔬 Tesla V100 GPU utilization: READY")
-else:
-    print(f"\n⚠️  {total-working} components need attention")
 
-print("\n🏆 MISSION ACCOMPLISHED!")
-print("   Tesla V100 + PyTorch 1.12.1 + diffusers 0.21.4 = SUCCESS")
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- prevent PyTest from collecting manual stable diffusion test scripts
- wrap stable diffusion environment tests in `main()`
- rename internal `test_import` helpers to avoid PyTest fixtures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d8588ca6883298e933b44b36eb8e2