### PR TITLE
Update docs and tests for Python 3.8 minimum

### DIFF
--- a/app-llama/README.md
+++ b/app-llama/README.md
@@ -63,7 +63,7 @@ DEFAULT_NUM_RETURN_SEQUENCES = 1
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.8+
 - PyTorch
 - Transformers (Hugging Face)
 - CUDA-capable GPU (recommended)

--- a/examples/README.md
+++ b/examples/README.md
@@ -81,7 +81,7 @@ A comprehensive demonstration script that shows:
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.8+
 - All framework dependencies (see `../requirements.txt`)
 - Access to GPU for profiling examples
 - Proper framework installation and configuration

--- a/sample-collection-scripts/legacy/profile_smi.py
+++ b/sample-collection-scripts/legacy/profile_smi.py
@@ -12,7 +12,7 @@ at regular intervals and saving them to CSV files for analysis.
 Requirements:
     - NVIDIA GPU with nvidia-smi support
     - nvidia-smi tool (part of NVIDIA drivers)
-    - Python 3.6+
+    - Python 3.8+
 
 Note:
     This is an alternative to the DCGMI-based profile.py script.

--- a/sample-collection-scripts/profile_smi.py
+++ b/sample-collection-scripts/profile_smi.py
@@ -12,7 +12,7 @@ at regular intervals and saving them to CSV files for analysis.
 Requirements:
     - NVIDIA GPU with nvidia-smi support
     - nvidia-smi tool (part of NVIDIA drivers)
-    - Python 3.6+
+    - Python 3.8+
 
 Note:
     This is an alternative to the DCGMI-based profile.py script.

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ The test suite ensures the framework works correctly across different Python ver
 ## Test Files
 
 ### **Configuration Tests**
-- **`test_configuration.py`** - Tests configuration module loading and Python 3.6+ compatibility
+- **`test_configuration.py`** - Tests configuration module loading and Python 3.8+ compatibility
 
 ### **Compatibility Tests**  
 - **`run_tests.py`** - Entry point for running the full test suite
@@ -60,12 +60,12 @@ pytest -v
 - ✅ DCGMI fields configuration
 - ✅ GPU frequency settings (A100/V100)
 - ✅ Model configuration parameters
-- ✅ Python 3.6+ class compatibility
+- ✅ Python 3.8+ class compatibility
 
 ### Subprocess Testing  
 - ✅ `run_command()` function with output capture
 - ✅ `run_command()` function without output capture
-- ✅ Python 3.6+ subprocess.run() compatibility
+- ✅ Python 3.8+ subprocess.run() compatibility
 - ✅ Error handling and timeout functionality
 
 ### Compatibility Testing
@@ -100,7 +100,7 @@ pytest -v
 
 ## Requirements
 
-- Python 3.6+ (tests verify compatibility across versions)
+- Python 3.8+ (tests verify compatibility across versions)
 - Access to project modules (`config.py`, `utils.py`)
 - Basic shell environment for bash tests
 
@@ -127,7 +127,7 @@ chmod +x tests/*.sh
 python --version
 
 # Test with specific Python version
-python3.6 tests/test_configuration.py  # If available
+python3.8 tests/test_configuration.py  # If available
 ```
 
 ## Adding New Tests

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -92,10 +92,11 @@ class TestEnvironmentSetup(unittest.TestCase):
 
     def test_python_version_compatibility(self):
         """Test Python version compatibility."""
-        # Test minimum Python version (3.6+)
+        # Test minimum Python version (3.8+)
         version_info = sys.version_info
         self.assertGreaterEqual(version_info.major, 3)
-        self.assertGreaterEqual(version_info.minor, 6)
+        if version_info.major == 3:
+            self.assertGreaterEqual(version_info.minor, 8)
 
     def test_required_imports(self):
         """Test that required external packages can be imported."""
@@ -128,7 +129,7 @@ class TestEnvironmentSetup(unittest.TestCase):
                     pass  # Optional packages are allowed to be missing
 
     def test_subprocess_compatibility(self):
-        """Test subprocess functionality for Python 3.6+ compatibility."""
+        """Test subprocess functionality for Python 3.8+ compatibility."""
         import subprocess
 
         # Test basic subprocess functionality


### PR DESCRIPTION
## Summary
- align docs with Python 3.8 minimum requirement
- enforce Python 3.8+ in `test_configuration.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875493850c48329b9aaddfa5587f509