### PR TITLE
Add GPU usage guide and fix documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,6 @@ The framework includes **streamlined documentation** focused on practical usage:
 - **[SUBMIT_JOBS_README.md](documentation/SUBMIT_JOBS_README.md)**: SLURM submission guide and HPC cluster deployment
 
 ### 📋 **Additional Module Documentation**
-- **[examples/README.md](examples/README.md)**: Usage examples and demonstrations
 - **[sample-collection-scripts/README.md](sample-collection-scripts/README.md)**: Profiling framework documentation
 - **[app-stable-diffusion/README.md](app-stable-diffusion/README.md)**: Modernized Stable Diffusion application with latest models
 - **[app-whisper/README.md](app-whisper/README.md)**: OpenAI Whisper speech recognition for audio processing energy profiling

--- a/documentation/GPU_USAGE_GUIDE.md
+++ b/documentation/GPU_USAGE_GUIDE.md
@@ -1,0 +1,31 @@
+# GPU Usage Guide
+
+This guide outlines basic GPU setup checks and usage patterns for running inference energy profiling.
+
+## GPU Setup
+
+1. **Verify drivers and tools**
+   ```bash
+   nvidia-smi            # confirm GPU visibility
+   dcgmi discovery --list  # optional: check DCGM interface
+   ```
+2. **Confirm Python environment** – ensure required packages are installed.
+
+## Running Profiling Scripts
+
+Use the launch script inside `sample-collection-scripts` to run workloads. The script automatically detects the GPU type and chooses an appropriate profiling tool.
+
+```bash
+cd sample-collection-scripts
+./launch_v2.sh --gpu-type A100 --app-name LSTM --profiling-mode baseline
+```
+
+See [USAGE_EXAMPLES.md](USAGE_EXAMPLES.md) for more command examples and [SUBMIT_JOBS_README.md](SUBMIT_JOBS_README.md) for batch submission instructions.
+
+## Troubleshooting
+
+If profiling tools are missing or GPUs are not visible:
+
+- Reinstall NVIDIA drivers or ensure you are inside a GPU-enabled environment.
+- Run `sudo nvidia-smi --gpu-reset` to reset a stuck GPU.
+- Consult the repository [README](../README.md) for additional tips.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -15,7 +15,7 @@ This directory contains comprehensive documentation for the AI Inference Energy
 1. **[`GPU_USAGE_GUIDE.md`](GPU_USAGE_GUIDE.md)** - Start here for GPU-specific setup and usage
 2. **[`USAGE_EXAMPLES.md`](USAGE_EXAMPLES.md)** - Learn the CLI interface with examples
 3. **[`SUBMIT_JOBS_README.md`](SUBMIT_JOBS_README.md)** - Submit jobs to HPC clusters
-4. **[`../sample-collection-scripts/V100_SCRIPT_GUIDE.md`](../sample-collection-scripts/V100_SCRIPT_GUIDE.md)** - V100 unified submission script guide
+4. **[`../sample-collection-scripts/README.md`](../sample-collection-scripts/README.md)** - Submission script guide
 
 ### For Researchers and Advanced Users  
 1. **[`GPU_USAGE_GUIDE.md`](GPU_USAGE_GUIDE.md)** - Complete GPU specifications and performance characteristics
@@ -94,7 +94,6 @@ All documentation follows consistent patterns:
 
 ### Project Root Documentation
 - **[`../README.md`](../README.md)** - Main project overview and installation guide
-- **[`../examples/README.md`](../examples/README.md)** - Usage examples and demonstrations
 
 ### Application-Specific Documentation  
 - **[`../sample-collection-scripts/README.md`](../sample-collection-scripts/README.md)** - Profiling framework and scripts


### PR DESCRIPTION
## Summary
- Add GPU_USAGE_GUIDE with basic GPU setup, profiling command, and troubleshooting notes.
- Remove broken documentation links and point references to existing files.

## Testing
- `pytest` *(fails: SystemExit: 1 importing WhisperViaHF)*

------
https://chatgpt.com/codex/tasks/task_e_68925ac0918c83299e9cddd6c035dd60