### PR TITLE
Handle single frequency count

### DIFF
--- a/hardware/gpu_info.py
+++ b/hardware/gpu_info.py
@@ -175,6 +175,8 @@ class GPUSpecifications:
                 frequencies.append(freq)
                 freq += freq_spec.step_size
         else:
+            if freq_spec.count <= 1:
+                return [freq_spec.min_freq]
             # Use count to determine approximate step size
             step = (freq_spec.max_freq - freq_spec.min_freq) / (freq_spec.count - 1)
             for i in range(freq_spec.count):

--- a/tests/test_hardware_module.py
+++ b/tests/test_hardware_module.py
@@ -9,6 +9,7 @@ ensuring all specifications, validation, and functionality work correctly.
 import sys
 import unittest
 from pathlib import Path
+import copy
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -117,6 +118,18 @@ class TestFrequencyManagement(unittest.TestCase):
 
                 # Check frequencies are sorted in descending order
                 self.assertEqual(frequencies, sorted(frequencies, reverse=True))
+
+    def test_single_frequency_case(self):
+        """Ensure single-frequency specifications return a single value."""
+        gpu_info = get_gpu_info("V100")
+        gpu_info.specifications = copy.deepcopy(gpu_info.specifications)
+        gpu_info.specifications["frequency"] = {
+            "min_freq": 1234,
+            "max_freq": 1234,
+            "count": 1,
+        }
+        frequencies = gpu_info.get_available_frequencies()
+        self.assertEqual(frequencies, [1234])
 
     def test_frequency_validation(self):
         """Test frequency validation functionality."""


### PR DESCRIPTION
## Summary
- guard against `count <= 1` in `get_available_frequencies`
- test single-frequency frequency specification

## Testing
- `pytest tests/test_hardware_module.py -q`
- `pytest -q` *(fails: Missing required dependency: No module named 'torchaudio')*


------
https://chatgpt.com/codex/tasks/task_e_68925a4ef7c08329987d3ae47a721099