### PR TITLE
docs: fix heading typo

### DIFF
--- a/app-vision-transformer/README.md
+++ b/app-vision-transformer/README.md
@@ -121,7 +121,7 @@ ViT experiments can be submitted through the job submission system:
 - Increase batch size for better throughput (within memory limits)
 - Pre-download sample images to reduce network overhead
 
-## Files Structure
+## File Structure
 
 ```
 app-vision-transformer/


### PR DESCRIPTION
## Summary
- fix incorrect "Files Structure" heading in ViT README

## Testing
- `pre-commit run --files app-vision-transformer/README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68925ab9c2248329a5bf27eab48e2db0