### PR TITLE
Fix benchmark image cycling

### DIFF
--- a/app-vision-transformer/ViTViaHF.py
+++ b/app-vision-transformer/ViTViaHF.py
@@ -293,10 +293,10 @@ class ViTViaHF:
             for i in range(min(num_images, len(sample_urls))):
                 image = self.download_sample_image(sample_urls[i % len(sample_urls)])
                 images.append(image)
-                
+
             # Fill remaining with repeated images if needed
             while len(images) < num_images:
-                images.append(images[i % len(sample_urls)])
+                images.append(images[len(images) % len(sample_urls)])
                 
             # Warm up
             logger.info("Warming up model...")


### PR DESCRIPTION
## Summary
- Ensure run_benchmark cycles through sample URLs when num_images exceeds available URLs

## Testing
- `python - <<'PY'
import sys, types, importlib.util
sys.modules['GPUtil'] = types.SimpleNamespace(getGPUs=lambda: [])
spec = importlib.util.spec_from_file_location('ViTViaHF', 'app-vision-transformer/ViTViaHF.py')
ViT_module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(ViT_module)
ViTViaHF = ViT_module.ViTViaHF

class DummyViT(ViTViaHF):
    def __init__(self):
        super().__init__(device='cpu')
        self.processed_images = []
    def download_sample_image(self, url: str):
        return url
    def classify_image(self, image, top_k: int = 5):
        self.processed_images.append(image)
        return [("dummy", 1.0)]

vit = DummyViT()
vit.run_benchmark(num_images=12, batch_size=4)
print('Processed images (excluding warmup):')
for idx, img in enumerate(vit.processed_images[3:]):
    print(idx, img)
PY`
- `pytest -q` *(fails: No module named 'torchaudio')*

------
https://chatgpt.com/codex/tasks/task_e_68925abaf50c8329afaedeb5da476eab