### PR TITLE
Add GPU usage guide and fix broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,6 @@ The framework includes **streamlined documentation** focused on practical usage:
 - **[SUBMIT_JOBS_README.md](documentation/SUBMIT_JOBS_README.md)**: SLURM submission guide and HPC cluster deployment
 
 ### 📋 **Additional Module Documentation**
-- **[examples/README.md](examples/README.md)**: Usage examples and demonstrations
 - **[sample-collection-scripts/README.md](sample-collection-scripts/README.md)**: Profiling framework documentation
 - **[app-stable-diffusion/README.md](app-stable-diffusion/README.md)**: Modernized Stable Diffusion application with latest models
 - **[app-whisper/README.md](app-whisper/README.md)**: OpenAI Whisper speech recognition for audio processing energy profiling

--- a/documentation/GPU_USAGE_GUIDE.md
+++ b/documentation/GPU_USAGE_GUIDE.md
@@ -1,0 +1,46 @@
+# GPU Usage Guide
+
+This guide summarizes GPU setup and usage for the AI Inference Energy profiling framework. It covers verifying GPU availability, launching jobs, and basic troubleshooting for NVIDIA A100, V100 and H100 devices.
+
+## GPU Setup
+
+1. **Verify GPU visibility**
+   ```bash
+   nvidia-smi
+   ```
+2. **Check optional DCGM tools**
+   ```bash
+   dcgmi discovery --list
+   ```
+3. **Configure environments** – see [USAGE_EXAMPLES.md](USAGE_EXAMPLES.md) for CLI examples and environment tips.
+
+## Running the Framework
+
+Launch profiling from the `sample-collection-scripts` directory:
+
+```bash
+cd ../sample-collection-scripts
+./launch_v2.sh --gpu-type A100 --profiling-mode baseline
+```
+
+### GPU Notes
+
+- **A100** – use `--gpu-type A100`; requires HPCC toreador nodes.
+- **V100** – use `--gpu-type V100` for matador nodes.
+- **H100** – use `--gpu-type H100` for REPACSS systems.
+
+## Troubleshooting
+
+```bash
+# Reset GPU if necessary
+sudo nvidia-smi --gpu-reset
+
+# Test configuration
+./launch_v2.sh --help
+```
+
+## Related Documentation
+
+- [USAGE_EXAMPLES.md](USAGE_EXAMPLES.md)
+- [SUBMIT_JOBS_README.md](SUBMIT_JOBS_README.md)
+- [../sample-collection-scripts/README.md](../sample-collection-scripts/README.md)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -15,7 +15,7 @@ This directory contains comprehensive documentation for the AI Inference Energy
 1. **[`GPU_USAGE_GUIDE.md`](GPU_USAGE_GUIDE.md)** - Start here for GPU-specific setup and usage
 2. **[`USAGE_EXAMPLES.md`](USAGE_EXAMPLES.md)** - Learn the CLI interface with examples
 3. **[`SUBMIT_JOBS_README.md`](SUBMIT_JOBS_README.md)** - Submit jobs to HPC clusters
-4. **[`../sample-collection-scripts/V100_SCRIPT_GUIDE.md`](../sample-collection-scripts/V100_SCRIPT_GUIDE.md)** - V100 unified submission script guide
+4. **[`../sample-collection-scripts/docs/JOB_SCRIPT_GUIDE_V100.md`](../sample-collection-scripts/docs/JOB_SCRIPT_GUIDE_V100.md)** - V100 unified submission script guide
 
 ### For Researchers and Advanced Users  
 1. **[`GPU_USAGE_GUIDE.md`](GPU_USAGE_GUIDE.md)** - Complete GPU specifications and performance characteristics
@@ -94,7 +94,6 @@ All documentation follows consistent patterns:
 
 ### Project Root Documentation
 - **[`../README.md`](../README.md)** - Main project overview and installation guide
-- **[`../examples/README.md`](../examples/README.md)** - Usage examples and demonstrations
 
 ### Application-Specific Documentation  
 - **[`../sample-collection-scripts/README.md`](../sample-collection-scripts/README.md)** - Profiling framework and scripts


### PR DESCRIPTION
## Summary
- Add new GPU usage guide with setup, launch, and troubleshooting instructions.
- Remove stale references to non-existent `examples` docs and fix link to V100 job script guide.

## Testing
- `pytest` *(fails: SystemExit in app-whisper/WhisperViaHF.py)*

------
https://chatgpt.com/codex/tasks/task_e_68925ad698e48329a72e42363e477d90