### PR TITLE
Handle case-insensitive LLaMA model shorthands

### DIFF
--- a/app-llama/LlamaViaHF.py
+++ b/app-llama/LlamaViaHF.py
@@ -127,8 +127,9 @@ class LlamaInferenceEngine:
         
     def _resolve_model_name(self, model_name: str) -> str:
         """Resolve model name from shorthand to full Hugging Face identifier."""
-        if model_name in DEFAULT_MODELS:
-            resolved = DEFAULT_MODELS[model_name]
+        key = model_name.lower()
+        if key in DEFAULT_MODELS:
+            resolved = DEFAULT_MODELS[key]
             self.logger.info(f"Resolved model shorthand '{model_name}' to '{resolved}'")
             return resolved
         return model_name

--- a/tests/test_llama_via_hf.py
+++ b/tests/test_llama_via_hf.py
@@ -1,0 +1,13 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "LlamaViaHF", Path(__file__).resolve().parents[1] / "app-llama" / "LlamaViaHF.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def test_resolve_model_name_case_insensitive():
+    engine = module.LlamaInferenceEngine(model_name="LLAMA-7B", device="cpu")
+    assert engine.model_name == "huggyllama/llama-7b"


### PR DESCRIPTION
## Summary
- Allow `_resolve_model_name` to look up model shorthands in a case-insensitive manner.
- Add regression test ensuring mixed-case shorthands resolve to the proper Hugging Face identifiers.

## Testing
- `pytest tests/test_llama_via_hf.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68925b10fe4c832994c23e38786f8407