### PR TITLE
Use csv module for robust CSV parsing

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,7 @@ This module provides common utility functions used across the profiling
 infrastructure, including logging setup, file operations, and system utilities.
 """
 
+import csv
 import logging
 import os
 import subprocess
@@ -155,6 +156,9 @@ def parse_csv_line(line: str, delimiter: str = ",") -> List[str]:
     """
     Parse a CSV line into fields.
 
+    Supports standard CSV quoting so delimiters within quoted fields are
+    handled correctly.
+
     Args:
         line: CSV line to parse
         delimiter: Field delimiter
@@ -162,7 +166,8 @@ def parse_csv_line(line: str, delimiter: str = ",") -> List[str]:
     Returns:
         List of parsed fields
     """
-    return [field.strip() for field in line.split(delimiter)]
+    reader = csv.reader([line], delimiter=delimiter)
+    return [field.strip() for field in next(reader)]
 
 
 def get_timestamp() -> str:


### PR DESCRIPTION
## Summary
- parse_csv_line now uses `csv.reader` for proper handling of quoted delimiters
- Updated parse_csv_line docstring to mention support for standard CSV quoting

## Testing
- `pytest` *(fails: SystemExit from app-whisper/WhisperViaHF.py)*
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d9b607e883298e0a3eab77ab27a2