### PR TITLE
fix: clean directory tree fenced block

### DIFF
--- a/app-stable-diffusion/README.md
+++ b/app-stable-diffusion/README.md
@@ -8,7 +8,6 @@ GPU-enabled Stable Diffusion implementation optimized for energy profiling and p
 
 ## Directory Structure
 ```
-```
 app-stable-diffusion/
 ├── StableDiffusionViaHF.py        # Modernized main application
 ├── README.md                      # This documentation
@@ -17,7 +16,6 @@ app-stable-diffusion/
 │   └── setup_stable_diffusion.sh # Setup script
 ├── tests/                        # Test suite and validation
 └── images/                       # Generated image outputs
-```
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- remove duplicated fence blocks around directory tree in Stable Diffusion README

## Testing
- `pytest` *(fails: SystemExit while importing app-whisper/WhisperViaHF)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d9b6f8e8832983e2c863205d13a4