### PR TITLE
test: add FileNotFoundError case for dcgmi

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,6 +81,9 @@ class TestUtilsValidation(unittest.TestCase):
         self.assertFalse(utils.validate_dcgmi_available())
         mock_run.side_effect = subprocess.CalledProcessError(1, "dcgmi")
         self.assertFalse(utils.validate_dcgmi_available())
+        mock_run.side_effect = FileNotFoundError
+        self.assertFalse(utils.validate_dcgmi_available())
+        mock_run.side_effect = None
 
 
 class TestRunCommandErrors(unittest.TestCase):


### PR DESCRIPTION
## Summary
- extend `validate_dcgmi_available` test to cover `FileNotFoundError`
- reset mock side effects to avoid cross-test interference

## Testing
- `pytest` *(fails: Missing required dependency: No module named 'librosa')*
- `pytest tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21feedfc48329a577fd634edc6e9f