### PR TITLE
Move visualization tools under analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,17 +154,17 @@ ai-inference-energy/
 │   │   ├── results/                                   # Analysis outputs and JSON data
 │   │   │   ├── edp_optimization_results.json          # Primary optimization results
 │   │   │   └── *.csv                                  # Detailed analysis tables
+│   │   ├── visualization/                             # Data visualization and plotting tools
+│   │   │   ├── visualize_edp_results.py               # 🎨 Experimental data visualization (scatter plots)
+│   │   │   ├── visualize_edp_summary.py               # 📊 Comprehensive summary analysis charts
+│   │   │   ├── README.md                              # Complete visualization system documentation
+│   │   │   └── edp-plots/                             # 🎨 Generated visualization files (16 total)
+│   │   │       ├── *_energy_performance_scatter.png   # Individual GPU-workload plots
+│   │   │       ├── energy_savings_comparison.png      # EDP vs ED²P comparison
+│   │   │       ├── frequency_optimization_comparison.png  # Frequency analysis
+│   │   │       ├── performance_impact_analysis.png    # Performance trade-offs
+│   │   │       └── comprehensive_summary.png          # 4-panel overview
 │   │   └── archived/                                  # Historical analysis tools and reports
-│   ├── visualization/                                 # Data visualization and plotting tools
-│   │   ├── visualize_edp_results.py                   # 🎨 Experimental data visualization (scatter plots)
-│   │   ├── visualize_edp_summary.py                   # 📊 Comprehensive summary analysis charts
-│   │   ├── README.md                                  # Complete visualization system documentation
-│   │   └── edp-plots/                                 # 🎨 Generated visualization files (16 total)
-│   │       ├── *_energy_performance_scatter.png       # Individual GPU-workload plots
-│   │       ├── energy_savings_comparison.png          # EDP vs ED²P comparison
-│   │       ├── frequency_optimization_comparison.png  # Frequency analysis
-│   │       ├── performance_impact_analysis.png        # Performance trade-offs
-│   │       └── comprehensive_summary.png              # 4-panel overview
 │   ├── (planned) optimal-frequency/                   # Planned frequency optimization tools (not in this release)
 │   ├── (planned) deployment/                          # Planned deployment interfaces (not in this release)
 │   ├── (planned) testing/                             # Planned extra testing tools (not in this release)
@@ -385,7 +385,7 @@ cat edp_optimization_results_summary.csv
 
 **Create comprehensive visualizations:**
 ```bash
-cd tools/visualization
+cd tools/analysis/visualization
 
 # Generate scatter plots with experimental data, outlier detection, and warm run averaging
 python visualize_edp_results.py
@@ -662,7 +662,7 @@ huggingface-cli whoami
 #### Visualization & Analysis Issues
 ```bash
 # Test visualization module imports
-cd tools/visualization
+cd tools/analysis/visualization
 python -c "import visualize_edp_results; print('✅ Visualization modules working')"
 
 # Check if experimental data exists
@@ -716,7 +716,7 @@ The framework includes **streamlined documentation** focused on practical usage:
 
 ### 📋 **Additional Module Documentation**
 - **[tools/README.md](tools/README.md)**: Advanced analysis and optimization tools documentation
-- **[tools/visualization/README.md](tools/visualization/README.md)**: Complete visualization system with outlier detection documentation
+- **[tools/analysis/visualization/README.md](tools/analysis/visualization/README.md)**: Complete visualization system with outlier detection documentation
 - **[sample-collection-scripts/README.md](sample-collection-scripts/README.md)**: Profiling framework documentation
 - **[app-stable-diffusion/README.md](app-stable-diffusion/README.md)**: Modernized Stable Diffusion application with latest models
 - **[app-whisper/README.md](app-whisper/README.md)**: OpenAI Whisper speech recognition for audio processing energy profiling

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,7 +5,7 @@ This directory contains all the analysis, deployment, and utility tools for the 
 ## Directory Structure
 
 ### 📊 Analysis (`analysis/`)
-Core analysis scripts for EDP (Energy-Delay Product) optimization:
+Core analysis scripts for EDP (Energy-Delay Product) optimization and visualization:
 - `edp_optimizer.py` - Main EDP & ED²P optimization engine
 - `edp_summary_tables.py` - EDP results summarization and table generation
 - `results/` - Analysis outputs
@@ -17,17 +17,15 @@ Core analysis scripts for EDP (Energy-Delay Product) optimization:
   - `power_modeling.py` - Power and performance modeling
   - `aggregate_data.py` - Data aggregation utilities
   - `comprehensive_report.py` - Report generation
-
-### 🎨 Visualization (`visualization/`)
-Comprehensive data visualization framework for experimental results:
-- **`visualize_edp_results.py`** - 🎨 **Real experimental data visualization** using DCGMI profiling data
-- **`visualize_edp_summary.py`** - 📊 **Comprehensive summary analysis** with comparative charts
-- **`README.md`** - Complete visualization system documentation
-- **`edp-plots/`** - Generated visualization outputs directory
-- **Generated Outputs:**
-  - 12 individual GPU-workload scatter plots using real DCGMI measurements
-  - 4 summary comparison charts and multi-GPU analysis
-  - Publication-quality 300 DPI PNG files
+- **`visualization/`** - Comprehensive data visualization framework for experimental results
+  - `visualize_edp_results.py` - 🎨 **Real experimental data visualization** using DCGMI profiling data
+  - `visualize_edp_summary.py` - 📊 **Comprehensive summary analysis** with comparative charts
+  - `README.md` - Complete visualization system documentation
+  - `edp-plots/` - Generated visualization outputs directory
+  - **Generated Outputs:**
+    - 12 individual GPU-workload scatter plots using real DCGMI measurements
+    - 4 summary comparison charts and multi-GPU analysis
+    - Publication-quality 300 DPI PNG files
 
 ### 📡 Data Collection (`data-collection/`)
 Data collection and profiling tools for GPU workloads:
@@ -68,11 +66,11 @@ cd tools/analysis
 python edp_optimizer.py --results-dir ../../sample-collection-scripts
 
 # 2. Generate individual scatter plots with DCGMI data
-cd ../visualization
-python visualize_edp_results.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+cd visualization
+python visualize_edp_results.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # 3. Create summary comparison analysis
-python visualize_edp_summary.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+python visualize_edp_summary.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # 4. View all 16 generated visualization files
 ls edp-plots/*.png
@@ -90,10 +88,10 @@ python tools/analysis/edp_optimizer.py
 python tools/analysis/edp_summary_tables.py
 
 # Experimental data visualization (RECOMMENDED)
-python tools/visualization/visualize_edp_results.py
+python tools/analysis/visualization/visualize_edp_results.py
 
 # Comprehensive summary analysis charts
-python tools/visualization/visualize_edp_summary.py
+python tools/analysis/visualization/visualize_edp_summary.py
 
 # Data collection with DCGMI profiling
 python tools/data-collection/profile.py

--- a/tools/analysis/README.md
+++ b/tools/analysis/README.md
@@ -18,7 +18,7 @@ This directory contains a comprehensive analysis suite for calculating Energy De
 ## Data Visualization Framework
 
 ### Key Enhancement: Experimental Data Integration
-The visualization system is located in `../visualization/` and has been **completely enhanced** to use **experimental data** from DCGMI profiling:
+The visualization system is located in `visualization/` and has been **completely enhanced** to use **experimental data** from DCGMI profiling:
 
 - **Real Power Measurements**: Direct integration with DCGMI CSV power profiles (50ms sampling)
 - **Actual Execution Times**: Timing data extracted from experimental summary logs
@@ -28,12 +28,12 @@ The visualization system is located in `../visualization/` and has been **comple
 
 ### Visualization Scripts Overview
 
-1. **`../visualization/visualize_edp_results.py`** - **Primary visualization script with data integration**
+1. **`visualization/visualize_edp_results.py`** - **Primary visualization script with data integration**
    - Uses actual DCGMI profiling data from `sample-collection-scripts/`
    - Creates individual scatter plots for each GPU-workload combination
    - Clear annotations showing EDP/ED²P optimal points with measurements
 
-2. **`../visualization/visualize_edp_summary.py`** - **Comparative analysis and summary plots**
+2. **`visualization/visualize_edp_summary.py`** - **Comparative analysis and summary plots**
    - Energy savings comparison between EDP and ED²P strategies
    - Frequency optimization analysis across GPU architectures
    - Performance impact visualization with statistical analysis
@@ -65,11 +65,11 @@ python edp_optimizer.py --results-dir ../../sample-collection-scripts
 python edp_summary_tables.py --csv
 
 # 3. Create individual scatter plots using experimental data
-cd ../visualization
-python visualize_edp_results.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+cd visualization
+python visualize_edp_results.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # 4. Generate comprehensive summary visualizations
-python visualize_edp_summary.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+python visualize_edp_summary.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # 5. View all 16 generated visualization files
 ls edp-plots/*.png
@@ -88,11 +88,11 @@ python edp_optimizer.py --results-dir ../../sample-collection-scripts
 python edp_summary_tables.py --csv
 
 # Create visualizations with experimental data (RECOMMENDED)
-cd ../visualization
-python visualize_edp_results.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+cd visualization
+python visualize_edp_results.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # Create comparative summary analysis
-python visualize_edp_summary.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+python visualize_edp_summary.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 ```
 
 ### Advanced Usage
@@ -288,11 +288,11 @@ The `visualize_edp_summary.py` script generates comparative analysis across all 
 ### Quick Visualization Workflow
 ```bash
 # Generate all individual plots (12 scatter plots)
-cd ../visualization
-python visualize_edp_results.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+cd visualization
+python visualize_edp_results.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # Generate all summary comparisons (4 summary plots)
-python visualize_edp_summary.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+python visualize_edp_summary.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # View results in edp-plots/ directory
 ```

--- a/tools/analysis/visualization/README.md
+++ b/tools/analysis/visualization/README.md
@@ -22,14 +22,14 @@ The visualization suite provides:
 ### Generate All Visualizations
 
 ```bash
-# From the tools/visualization directory
-cd tools/visualization
+# From the tools/analysis/visualization directory
+cd tools/analysis/visualization
 
 # 1. Create individual scatter plots with real experimental data
-python visualize_edp_results.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+python visualize_edp_results.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # 2. Generate comprehensive summary visualizations
-python visualize_edp_summary.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+python visualize_edp_summary.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 
 # 3. View all generated visualization files
 ls edp-plots/*.png
@@ -130,7 +130,7 @@ python edp_optimizer.py --results-dir ../../sample-collection-scripts
 python edp_summary_tables.py --csv
 
 # 3. Create visualizations
-cd ../visualization
-python visualize_edp_results.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
-python visualize_edp_summary.py --input ../analysis/results/edp_optimization_results.json --output-dir edp-plots
+cd visualization
+python visualize_edp_results.py --input ../results/edp_optimization_results.json --output-dir edp-plots
+python visualize_edp_summary.py --input ../results/edp_optimization_results.json --output-dir edp-plots
 ```

--- a/tools/analysis/visualization/visualize_edp_results.py
+++ b/tools/analysis/visualization/visualize_edp_results.py
@@ -74,7 +74,11 @@ class DataVisualizer:
             output_dir: Output directory for plots
         """
         self.results_file = Path(results_file)
-        self.sample_scripts_dir = Path(sample_scripts_dir) if sample_scripts_dir else Path("../../sample-collection-scripts")
+        self.sample_scripts_dir = (
+            Path(sample_scripts_dir)
+            if sample_scripts_dir
+            else Path("../../../sample-collection-scripts")
+        )
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -93,7 +97,7 @@ class DataVisualizer:
     def find_result_directory(self, gpu: str, workload: str) -> Optional[Path]:
         """Find the experimental results directory for a GPU-workload combination"""
         # Define base directory for experimental results
-        base_dir = Path("../../sample-collection-scripts")
+        base_dir = Path("../../../sample-collection-scripts")
 
         if not base_dir.exists():
             print(f"Warning: Sample collection scripts directory not found: {base_dir}")
@@ -727,7 +731,7 @@ def main():
     parser.add_argument(
         "--input",
         "-i",
-        default="../analysis/results/edp_optimization_results.json",
+        default="../results/edp_optimization_results.json",
         help="Input JSON file with optimization results",
     )
     parser.add_argument("--output-dir", "-o", default="edp-plots", help="Output directory for plot files")

--- a/tools/analysis/visualization/visualize_edp_summary.py
+++ b/tools/analysis/visualization/visualize_edp_summary.py
@@ -380,7 +380,7 @@ def main():
     parser.add_argument(
         "--input",
         "-i",
-        default="../analysis/results/edp_optimization_results.json",
+        default="../results/edp_optimization_results.json",
         help="Input JSON file with optimization results",
     )
     parser.add_argument("--output-dir", "-o", default="edp-plots", help="Output directory for plot files")


### PR DESCRIPTION
## Summary
- Move visualization utilities into `tools/analysis/visualization`
- Point visualization scripts to new locations and sample data paths
- Refresh documentation and usage instructions for relocated visualization tools

## Testing
- `pytest` *(fails: SystemExit: 1 in app-whisper/WhisperViaHF import)*
- `python tools/analysis/visualization/visualize_edp_results.py --help`
- `python tools/analysis/visualization/visualize_edp_summary.py --help`
- `rg "tools/visualization" -n`

------
https://chatgpt.com/codex/tasks/task_e_68b85ea452748329b6249e5362bf7122