### PR TITLE
docs: fix heterogeneous spelling in GPU query

### DIFF
--- a/documentation/nvidia-smi-help-query-gpu.txt
+++ b/documentation/nvidia-smi-help-query-gpu.txt
@@ -10,7 +10,7 @@ Section about vgpu_driver_capability properties
 Retrieves information about driver level caps.
 
 "vgpu_driver_capability.heterogenous_multivGPU"
-Whether heterogeneuos multi-vGPU is supported by driver.
+Whether heterogeneous multi-vGPU is supported by driver.
 
 "count"
 The number of NVIDIA GPUs in the system.


### PR DESCRIPTION
## Summary
- fix spelling of "heterogeneous" in vgpu_driver_capability description

## Testing
- `pytest -q` *(fails: Missing required dependency No module named 'librosa')*


------
https://chatgpt.com/codex/tasks/task_e_68bccd0fc4888329b0f964f918754c67