### PR TITLE
Sort available GPU frequency lists in descending order

### DIFF
--- a/hardware/gpu_info.py
+++ b/hardware/gpu_info.py
@@ -162,24 +162,26 @@ class GPUSpecifications:
         """Get list of all available frequencies in MHz."""
         freq_spec = self.get_frequency_specification()
         if freq_spec.frequencies:
-            return freq_spec.frequencies.copy()
-
-        # Generate frequency list if not explicitly provided
-        frequencies = []
-        if freq_spec.step_size:
-            freq = freq_spec.min_freq
-            while freq <= freq_spec.max_freq:
-                frequencies.append(freq)
-                freq += freq_spec.step_size
+            frequencies = freq_spec.frequencies.copy()
         else:
-            if freq_spec.count <= 1:
-                return [freq_spec.min_freq]
-            # Use count to determine approximate step size
-            step = (freq_spec.max_freq - freq_spec.min_freq) / (freq_spec.count - 1)
-            for i in range(freq_spec.count):
-                freq = freq_spec.min_freq + int(i * step)
-                frequencies.append(freq)
+            # Generate frequency list if not explicitly provided
+            frequencies = []
+            if freq_spec.step_size:
+                freq = freq_spec.min_freq
+                while freq <= freq_spec.max_freq:
+                    frequencies.append(freq)
+                    freq += freq_spec.step_size
+            else:
+                if freq_spec.count <= 1:
+                    frequencies = [freq_spec.min_freq]
+                else:
+                    # Use count to determine approximate step size
+                    step = (freq_spec.max_freq - freq_spec.min_freq) / (freq_spec.count - 1)
+                    for i in range(freq_spec.count):
+                        freq = freq_spec.min_freq + int(i * step)
+                        frequencies.append(freq)
 
+        frequencies.sort(reverse=True)
         return frequencies
 
     def get_memory_specification(self) -> MemorySpecification:


### PR DESCRIPTION
## Summary
- Ensure `GPUSpecifications.get_available_frequencies` always returns frequencies sorted from high to low.

## Testing
- `pytest tests/test_hardware_module.py`
- `pre-commit run --files hardware/gpu_info.py` *(fails: command not found, installation blocked by missing proxy access)*

------
https://chatgpt.com/codex/tasks/task_e_68bccd181750832998cc5d457dca0788