### PR TITLE
docs: document integration option in hardware example

### DIFF
--- a/hardware/hardware_example.py
+++ b/hardware/hardware_example.py
@@ -7,7 +7,7 @@ which provides comprehensive specifications and validation for
 NVIDIA GPU architectures used in AI inference energy profiling.
 
 Usage:
-    python hardware_example.py [--gpu-type V100|A100|H100] [--compare-all]
+    python hardware_example.py [--gpu-type V100|A100|H100] [--compare-all] [--integration]
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- mention --integration flag in hardware_example usage instructions

## Testing
- `pre-commit run --files hardware/hardware_example.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Cannot connect to proxy. No matching distribution found for pre-commit)*
- `pytest` *(fails: No module named 'librosa')*

------
https://chatgpt.com/codex/tasks/task_e_68bccd21b95c832981b6886412f10a15