### PR TITLE
Add test for quoted CSV parsing case

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,8 @@ class TestUtilsParsing(unittest.TestCase):
         self.assertEqual(utils.parse_csv_line(line), ["a", "b", "c"])
         line_semicolon = "1;2;3"
         self.assertEqual(utils.parse_csv_line(line_semicolon, delimiter=";"), ["1", "2", "3"])
+        line_quotes = '"a,1",b'
+        self.assertEqual(utils.parse_csv_line(line_quotes), ["a,1", "b"])
 
     def test_clean_filename(self):
         dirty = "inva:lid/fi*le?name.txt"


### PR DESCRIPTION
## Summary
- extend parse_csv_line test coverage for quoted fields containing delimiters

## Testing
- `pytest tests/test_utils.py::TestUtilsParsing::test_parse_csv_line -q`
- `pytest tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bccd24fb8c832984d0a696487c1d3d