### PR TITLE
Improve app parameter parsing in launch_v2.sh

### DIFF
--- a/sample-collection-scripts/launch_v2.sh
+++ b/sample-collection-scripts/launch_v2.sh
@@ -173,10 +173,8 @@ run_profiling_experiment() {
     # Parse application parameters into array
     local app_params_array=()
     if [[ -n "$PARSED_APP_PARAMS" ]]; then
-        # Use bash read to properly parse quoted parameters
-        while IFS= read -r -d '' param; do
-            app_params_array+=("$param")
-        done < <(printf '%s\0' $PARSED_APP_PARAMS)
+        eval "set -- $PARSED_APP_PARAMS"
+        app_params_array=("$@")
     fi
 
     log_debug "Application parameters: ${#app_params_array[@]} items"


### PR DESCRIPTION
## Summary
- simplify application parameter parsing in `launch_v2.sh` using `eval` and arrays
- ensure parameters with spaces and quotes are preserved for downstream execution

## Testing
- `pytest` *(fails: Module `WhisperViaHF` exits with SystemExit, preventing tests)*
- `sample-collection-scripts/launch_v2.sh --help`
- `sample-collection-scripts/submit_job_v100.sh` *(fails: module command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72f7968f08329af9f7a93c2df6489