### PR TITLE
Add test for validate_gpu_available on CalledProcessError

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,6 +76,11 @@ class TestUtilsValidation(unittest.TestCase):
         self.assertFalse(utils.validate_gpu_available())
 
     @patch("utils.run_command")
+    def test_validate_gpu_available_calledprocesserror(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(1, "nvidia-smi")
+        self.assertFalse(utils.validate_gpu_available())
+
+    @patch("utils.run_command")
     def test_validate_dcgmi_available(self, mock_run):
         mock_run.return_value = CompletedProcess([], 0, stdout="", stderr="")
         self.assertTrue(utils.validate_dcgmi_available())


### PR DESCRIPTION
## Summary
- add unit test for validate_gpu_available handling of CalledProcessError

## Testing
- `pytest tests/test_utils.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68c72f888ba88329ad136d1d64947817